### PR TITLE
Marmalade compatibility

### DIFF
--- a/grizzl-pkg.el
+++ b/grizzl-pkg.el
@@ -1,18 +1,3 @@
-;;; grizzl.el --- A fuzzy search index & completing read.
-
-;; Copyright © 2013 Chris Corbyn
-;;
-;; Author:   Chris Corbyn <chris@w3style.co.uk>
-;; URL:      https://github.com/d11wtq/grizzl
-;; Version:  0.1.1
-;; Keywords: convenience, usability
-
-;; This file is NOT part of GNU Emacs.
-
-;;; --- License
-
-;; Licensed under the same terms as Emacs.
-
 (define-package "grizzl" "0.1.1"
   "Fuzzy Search Library & Completing Read"
   '((cl-lib "0.1")))


### PR DESCRIPTION
The comments in the `pkg` file were confusing Marmalade's parser. I had
to remove them to be able to upload the package to Marmalade.
