### PR TITLE
Fix out of bound exception from `cl-seq'.

### DIFF
--- a/grizzl.el
+++ b/grizzl.el
@@ -137,7 +137,7 @@ If the :END option is specified, up to :END results are returned."
   (let* ((matches (grizzl-result-matches result))
          (strings (grizzl-index-strings index))
          (loaded '())
-         (start (plist-get options :start))
+         (start (or (plist-get options :start) 0))
          (end (plist-get options :end)))
     (maphash (lambda (string-offset char-offset)
                (push string-offset loaded))
@@ -146,9 +146,11 @@ If the :END option is specified, up to :END results are returned."
                           (lambda (a b)
                             (< (cadr (gethash a matches))
                                (cadr (gethash b matches))))))
+
+           (end (and end (min end (length ordered))))
            (best (if (or start end)
                      (cl-delete-if-not 'identity
-                                       (cl-subseq ordered (or start 0) end))
+                                       (cl-subseq ordered start end))
                    ordered)))
       (mapcar (lambda (n)
                 (car (elt strings n)))


### PR DESCRIPTION
* grizzl.el (grizzl-result-strings): Make sure the end value passed to
  `cl-seq' is <= the length of the list.

This is a slightly different version to fix the same problem referenced in pull request https://github.com/grizzl/grizzl/pull/24. 

Note that all tests pass when run against emacs HEAD.