### PR TITLE
Truncate lines in grizzl overlay

### DIFF
--- a/grizzl.el
+++ b/grizzl.el
@@ -298,6 +298,7 @@ Each key pressed in the minibuffer filters down the list of matches."
       (lambda ()
         (setq *grizzl-current-result* nil)
         (setq *grizzl-current-selection* 0)
+        (setq truncate-lines t)
         (grizzl-mode 1)
         (let* ((hookfun (lambda ()
                           (setq *grizzl-current-result*


### PR DESCRIPTION
Lines too long will break the height calculation in grizzl resulting in blank overlay

See `grizzl-display-result' `set-window-text-height'.

Related:

https://github.com/grizzl/grizzl/issues/13
https://github.com/grizzl/grizzl/issues/14